### PR TITLE
173190629 Fix email verification response

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -44,7 +44,7 @@ class AuthController {
         await AuthHelper.sendMail(email, token);
         res.status(201).send({
           status: 201,
-          message: 'Account created succesfully, check your email for verification',
+          message: 'Account has been created successfully. Check your email for a verification link.'
         });
       }
     } catch (error) {
@@ -64,16 +64,11 @@ class AuthController {
    */
   static async verifyEmail(req, res) {
     const { token } = req.params;
-    const { id, email, username } = await TokenHelper.verifyToken(token);
+    const { id } = await TokenHelper.verifyToken(token);
     try {
       if (id) {
         AuthHelper.verifyUserEmail(id);
-        res.status(200).send({
-          userid: id,
-          email,
-          username,
-          message: ' Your email has been successfully verified',
-        });
+        res.redirect('https://champs-frontend.herokuapp/verification');
       } else {
         res.status(400).send({
           status: 400,

--- a/server/tests/auth.test.js
+++ b/server/tests/auth.test.js
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
 import { config } from 'dotenv';
+import request from 'supertest';
 import app from '../index';
 
 config();
@@ -90,13 +91,11 @@ describe('GET token to verify sign up', () => {
 
   it('should return an object ', (done) => {
     const token = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZW1haWwiOiJhZ2d5cmVpbmFAZ21haWwuY29tIiwiaWF0IjoxNTg2Mzg3NDk3fQ.G2huyQ7JiLvQjgaaUIkXZNXs0OHwRY35RirFgOGkV3I';
-    router()
-      .get(`/api/v1/auth/verify/${token}`)
+    request(app).get(`/api/v1/auth/verify/${token}`)
+      .expect(302)
       .end((err, res) => {
-        expect(res).to.have.status(200);
-        expect(res.body).to.be.a('object');
-        expect(res.body).to.have.property('message');
-        done(err);
+        expect(res).to.have.status(302);
+        done();
       });
   });
 });

--- a/server/tests/passwordResetTest.test.js
+++ b/server/tests/passwordResetTest.test.js
@@ -7,7 +7,7 @@ const router = () => chai.request(app);
 
 describe('Test resetting user password endpoint', () => {
   const user = {
-    email: 'aggyreina@gmail.com',
+    email: 'aggy@gmail.com',
     email0: '',
     password: 'aggggg',
     passwordConfirm: 'aggggg',


### PR DESCRIPTION
#### Description
A chore to improve back-end(Server) to adapt and respond to front-end requests:
On email confirmation, the user will be redirected to the page where he'll be able to see that his email has verified and then go to sign in.

#### Type of change

Please select the relevant option

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update

#### How Has This Been Tested?

- [X] Unit
- [ ] Integration
- [ ] End-to-end
- [ ] No testing required

#### How to Test
Setup:

 1. Clone this repo on your machine
 2. Add `.env` file by referring to `.env.example`
 3. Go in the `swagger` file and change `host` address to `localhost:3000`
 4. Run `npm i ` to install dependencies
 5. Do `npm run serve` command

Test:

 1. Open your preferred testing tool, I would suggest using your browser
 2. Enter this link in the URL `localhost:3000/api/v1/auth/signup` to sign up using google.
 3. Sign up by providing your account firstname, lastname, username, email, and password.
 4. You will see a toast message to go to your email for a confirmation., then click on the given link and you'll be predicted to another telling you that your email has verified, then click on the button to go to sign in page.

#### Any background context you want to add (Optional)

N/A

#### STORY ID

[Fixes #173190629]