### PR TITLE
173254779 Password reset response

### DIFF
--- a/server/controllers/authController.js
+++ b/server/controllers/authController.js
@@ -68,7 +68,7 @@ class AuthController {
     try {
       if (id) {
         AuthHelper.verifyUserEmail(id);
-        res.redirect('https://champs-frontend.herokuapp.com/verification');
+        res.redirect('https://champs-frontend.herokuapp.com/verify-email');
       } else {
         res.status(400).send({
           status: 400,

--- a/server/controllers/passwordController.js
+++ b/server/controllers/passwordController.js
@@ -49,6 +49,17 @@ class PasswordController {
   }
 
   /**
+   *  This method handles the reset password operation.
+   * @param {object} req The user's request.
+   * @param {object} res The response.
+   * @returns {object} The status and some data of the user.
+   */
+  static async changePassword(req, res) {
+    const { email, token } = req.params;
+    res.redirect(`https://champs-frontend.herokuapp.com/reset-password?email=${email}&token=${token}`);
+  }
+
+  /**
      * This method updates user password.
      * @param {object} req The user's request.
      * @param {object} res The response.

--- a/server/helpers/authHelper.js
+++ b/server/helpers/authHelper.js
@@ -30,14 +30,18 @@ class AuthHelper {
       message = {
         to: email,
         from: 'champsdev2@gmail.com',
-        subject: 'Reset Password Link',
-        text: 'Reset Password Link',
+        subject: 'Password Reset Link',
+        text: 'Password Reset Link',
         html: `
         <div style="background-color: white;border: wheat 2px solid;padding: 20px;
         max-width: 50vw;margin: 50px;align-items: center;height: 45vh;">
-            <h1 style="font-size: 25px;margin-top: 30px;">You received the reset password link</h1>
-            <p style="font-family: fantasy;font-size: 20px;">Copy the following link and use it your favorite API testing platform such as Postman or Insomnia to reset your password: </p>
-            <p> ${url} </p>
+            <h1 style="font-size: 25px;margin-top: 30px;">You received a password reset link</h1>
+            <button style="background-color: rgb(11, 132, 212);
+            width: 130px;height: 30px;border: none;margin-top: 40px;
+            "><a href="${url}" style="text-decoration: none;color: white;font-size: 14px;
+            ">
+            Reset Password</a>
+            </button>
         </div>
         `,
       };
@@ -52,7 +56,7 @@ class AuthHelper {
       <div style="background-color: white;border: wheat 2px solid;padding: 20px;
       max-width: 50vw;margin: 50px;align-items: center;height: 45vh;">
           <h1 style="font-size: 25px;margin-top: 30px;">Welcome to Nomad champs</h1>
-          <p style="font-family: fantasy;font-size: 20px;">Comfirm your email to proceed to Nomad champs</p>
+          <p style="font-family: fantasy;font-size: 20px;">Confirm your email to proceed to Barefoot Nomad champs</p>
           <button style="background-color: rgb(11, 132, 212);
           width: 130px;height: 30px;border: none;margin-top: 40px;
           "><a href="${url}" style="text-decoration: none;color: white;font-size: 14px;

--- a/server/middleware/user.js
+++ b/server/middleware/user.js
@@ -29,11 +29,45 @@ class User {
     } catch (error) {
       return res.status(500).json({
         status: 500,
-        message: 'Something went wrong when verifying used email',
+        message: 'Something went wrong while verifying used email',
         error: error.message
       });
     }
   }
+
+  /**
+   * This method verifies whether email is registered.
+   * @param {object} req the user's request.
+   * @param {object} res the response.
+   * @param {Function} next pass to next function.
+   * @returns {object} message indicating used email.
+   */
+  static async verifyRegisteredEmail(req, res, next) {
+    try {
+      const { email } = req.body;
+      const registeredEmail = await UserHelper.findUser({ email });
+      if (registeredEmail === null) {
+        res.status(404).send({
+          status: 404,
+          message: 'Email is not registered in our system.'
+        });
+      } else if (registeredEmail.dataValues.isVerified === true) {
+        next();
+      } else {
+        res.status(400).send({
+          status: 400,
+          message: 'You should verify your email before you reset the password.'
+        });
+      }
+    } catch (error) {
+      return res.status(500).json({
+        status: 500,
+        message: 'Something went wrong while resetting your password.',
+        error: error.message
+      });
+    }
+  }
+
 
   /**
    * This method verifies whether username is used.

--- a/server/routes/authRoutes.js
+++ b/server/routes/authRoutes.js
@@ -14,8 +14,9 @@ router.get('/facebook', passport.authenticate('facebook', { scope: ['email'] }))
 router.get('/google/return', User.verifyGoogleSignIn, AuthController.socialSignIn);
 router.get('/facebook/return', User.verifyFacebookSignIn, AuthController.socialSignIn);
 router.get('/google', passport.authenticate('google', { scope: ['profile', 'email'] }));
-router.post('/reset-link', Validations.validateEmail, PasswordController.sendPasswordResetLink);
+router.post('/reset-link', Validations.validateEmail, User.verifyRegisteredEmail, PasswordController.sendPasswordResetLink);
 router.post('/signup', Validations.validateSignUpData, User.verifyUsedEmail, User.verifyUsedUsername, AuthController.signUp);
+router.get('/update-password/:email/:token', PasswordController.changePassword);
 router.post('/update-password/:email/:token', Validations.validatePasswordResetData, TokenHandler.verifyToken, PasswordController.resetPassword);
 
 export default router;

--- a/server/tests/passwordResetTest.test.js
+++ b/server/tests/passwordResetTest.test.js
@@ -1,5 +1,6 @@
 import chai, { expect } from 'chai';
 import chaiHttp from 'chai-http';
+import request from 'supertest';
 import app from '../index';
 
 chai.use(chaiHttp);
@@ -8,7 +9,9 @@ const router = () => chai.request(app);
 describe('Test resetting user password endpoint', () => {
   const user = {
     email: 'aggy@gmail.com',
+    emailSuccess: 'chrischris@example.com',
     email0: '',
+    emailFail: 'aggyreina@gmail.com',
     password: 'aggggg',
     passwordConfirm: 'aggggg',
     password0: 'were123',
@@ -18,7 +21,7 @@ describe('Test resetting user password endpoint', () => {
   it('should send a password reset link email to a user', (done) => {
     router()
       .post('/api/v1/auth/reset-link')
-      .send({ email: user.email })
+      .send({ email: user.emailSuccess })
       .end((err, res) => {
         expect(res.body.status).to.be.equal(200);
         done();
@@ -68,6 +71,35 @@ describe('Test resetting user password endpoint', () => {
       .end((err, res) => {
         expect(res.body.status).to.be.equal(422);
         expect(res.body).to.have.property('error');
+        done();
+      });
+  });
+
+  it('should not send a password reset to a user, email does not exit in our system', (done) => {
+    router()
+      .post('/api/v1/auth/reset-link')
+      .send({ email: user.email })
+      .end((err, res) => {
+        expect(res.body.status).to.be.equal(404);
+        done();
+      });
+  });
+
+  it('should not send a password reset link to a user, email is not verified.', (done) => {
+    router()
+      .post('/api/v1/auth/reset-link')
+      .send({ email: user.emailFail })
+      .end((err, res) => {
+        expect(res.body.status).to.be.equal(400);
+        done();
+      });
+  });
+
+  it('should get password reset page', (done) => {
+    request(app).get(process.env.TEST_URL)
+      .expect(302)
+      .end((err, res) => {
+        expect(res).to.have.status(302);
         done();
       });
   });


### PR DESCRIPTION
#### Description

This PR is for fixing the password reset link page.
 
#### Type of change

Please select the relevant option

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Others (cosmetics, styling, improvements)
- [ ] This change requires a documentation update

#### How Has This Been Tested?

- [X] Unit
- [ ] Integration
- [ ] End-to-end
- [ ] No testing required

#### How to Test
Setup:

 1. Clone this repo on your machine
 2. Add `.env` file by referring to `.env.example`
 3. Go in the `swagger` file and change `host` address to `localhost:3000`
 4. Run `npm i ` to install dependencies
 5. Do `npm run serve` command

Test:

 1. Open your preferred testing tool, I would suggest using your browser
 2. Enter this link in the URL `localhost:3000/api/v1/auth/reset-link` to reset your password.
 3. Enter your email to reset your password.
 4. You will see a toast message to go to your email for a changing your password.

#### Any background context you want to add (Optional)

N/A

#### STORY ID

[Fixes #173254779]